### PR TITLE
Potential fix for code scanning alert no. 1: Unbounded write

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,7 +5,8 @@
 // バッファオーバーフローを意図的に発生
 void vulnerable_copy(const char* input) {
     char buffer[8];
-    strcpy(buffer, input);  // ✅ CodeQLが検出（CWE-121: Stack-based Buffer Overflow）
+    strncpy(buffer, input, sizeof(buffer) - 1);  // Copy up to 7 characters
+    buffer[sizeof(buffer) - 1] = '\0';  // Ensure null termination
     std::cout << "Copied: " << buffer << std::endl;
 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/researcherkk/for_code_scanning_test/security/code-scanning/1](https://github.com/researcherkk/for_code_scanning_test/security/code-scanning/1)

To fix the issue, we need to replace the unsafe `strcpy` function with a safer alternative, such as `strncpy`. The `strncpy` function allows us to specify the maximum number of characters to copy, ensuring that the destination buffer is not overrun. In this case, the buffer size is 8 bytes, so we will limit the copy to 7 characters (leaving 1 byte for the null terminator). Additionally, we will explicitly null-terminate the buffer to ensure it is properly terminated even if the input string is longer than 7 characters.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
